### PR TITLE
Add default parent to Kuma ingress watcher helm chart

### DIFF
--- a/charts/kuma-ingress-watcher/templates/deployment.yaml
+++ b/charts/kuma-ingress-watcher/templates/deployment.yaml
@@ -54,6 +54,8 @@ spec:
           value: "{{ .Values.kumaIngressWatcher.fileBasedMonitors.enabled | default `false` }}"
         - name: MONITORS_FILE_PATH
           value: "{{ .Values.kumaIngressWatcher.fileBasedMonitors.monitorsFilePath | default `/etc/kuma/monitors.yaml` }}"
+        - name: DEFAULT_PARENT
+          value: "{{ .Values.uptimeKuma.defaultParent }}"
         {{- if .Values.kumaIngressWatcher.fileBasedMonitors.enabled }}
         volumeMounts:
         - name: monitors-file

--- a/charts/kuma-ingress-watcher/values.yaml
+++ b/charts/kuma-ingress-watcher/values.yaml
@@ -44,6 +44,7 @@ deployment:
 uptimeKuma:
   url: "http://uptime-kuma:3001"
   credentialsSecret: uptime-kuma-credentials
+  defaultParent: ""
 
 resources:
   requests:


### PR DESCRIPTION
Add a helm value to control the default group probes get added to in Kuma

related PR:
https://github.com/SQuent/kuma-ingress-watcher/pull/41